### PR TITLE
Make pino-logger config optional

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -7,7 +7,7 @@ function Logger () {}
 Logger.preload = function () {
   var seneca = this
   var options = seneca.options()
-  var pino = options['pino-logger']
+  var pino = options['pino-logger'] || { }
 
   var logger = pino.instance || Pino(pino.config)
 

--- a/test/index.js
+++ b/test/index.js
@@ -30,4 +30,11 @@ describe('Pino Logger', () => {
     expect(seneca.log).to.exist()
     done()
   })
+
+  it('will allow absent pino-logger configuration', (done) => {
+    const seneca = Seneca({legacy: {logging: false}})
+    seneca.use(Logger)
+    expect(seneca.log).to.exist()
+    done()
+  })
 })


### PR DESCRIPTION
When I try to use `seneca-pino-logger` without explicitly specifying the configuration, I get the following error:

```
TypeError: Cannot read property 'instance' of undefined
```

It happens on [this line](https://github.com/senecajs/seneca-pino-logger/blob/master/pino.js#L12), where `pino` ends up being undefined due to absence of the `pino-logger` config key.

I checked the documentation of Pino logger, and it supports creating instances without an option. Therefore I do not see any reason to force plugin users to explicitly specify pino-logger options in seneca configuration.
